### PR TITLE
Add support for vcpkg package features

### DIFF
--- a/include/project_parser.hpp
+++ b/include/project_parser.hpp
@@ -33,7 +33,13 @@ struct Package {
 struct Vcpkg {
     std::string version;
     std::string url;
-    std::vector<std::string> packages;
+
+    struct Package {
+        std::string name;
+        std::vector<std::string> features;
+    };
+
+    std::vector<Package> packages;
 };
 
 enum TargetType {

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -611,24 +611,25 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
         const auto &packages = project.vcpkg.packages;
         for (size_t i = 0; i < packages.size(); i++) {
             const auto &package = packages[i];
+            const auto &features = package.features;
             if (!vcpkg_valid_identifier(package.name)) {
                 throw std::runtime_error("Invalid vcpkg package name '" + package.name + "'");
             }
-            for (const auto &feature : package.features) {
+            for (const auto &feature : features) {
 				if (!vcpkg_valid_identifier(feature)) {
 					throw std::runtime_error("Invalid vcpkg package feature '" + feature + "'");
 				}
             }
-            if (package.features.empty()) {
+            if (features.empty()) {
                 ofs << "    \"" << package.name << '\"';
             } else {
                 ofs << "    {\n";
                 ofs << "      \"name\": \"" << package.name << "\",\n";
                 ofs << "      \"features\": [";
-                for (size_t j = 0; j < package.features.size(); j++) {
-                    const auto &feature = package.features[j];
+                for (size_t j = 0; j < features.size(); j++) {
+                    const auto &feature = features[j];
                     ofs << '\"' << feature << '\"';
-                    if (j + 1 < package.features.size()) {
+                    if (j + 1 < features.size()) {
                         ofs << ',';
                     }
                 }

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -614,6 +614,11 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
             if (!vcpkg_valid_identifier(package.name)) {
                 throw std::runtime_error("Invalid vcpkg package name '" + package.name + "'");
             }
+            for (const auto &feature : package.features) {
+				if (!vcpkg_valid_identifier(feature)) {
+					throw std::runtime_error("Invalid vcpkg package feature '" + feature + "'");
+				}
+            }
             if (package.features.empty()) {
                 ofs << "    \"" << package.name << '\"';
             } else {

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -636,9 +636,9 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
                 ofs << "]\n";
                 ofs << "    }";
             }
-			if (i + 1 < packages.size()) {
-				ofs << ',';
-			}
+            if (i + 1 < packages.size()) {
+                ofs << ',';
+            }
             ofs << '\n';
         }
 

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -579,8 +579,8 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
 
         // Show a nicer error than vcpkg when specifying an invalid package name
         for (const auto &package : project.vcpkg.packages) {
-            if (!vcpkg_valid_identifier(package)) {
-                throw std::runtime_error("Invalid [vcpkg].packages name '" + package + "' (needs to be lowercase alphanumeric)");
+            if (!vcpkg_valid_identifier(package.name)) {
+                throw std::runtime_error("Invalid [vcpkg].packages name '" + package.name + "' (needs to be lowercase alphanumeric)");
             }
         }
 
@@ -611,13 +611,28 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
         const auto &packages = project.vcpkg.packages;
         for (size_t i = 0; i < packages.size(); i++) {
             const auto &package = packages[i];
-            if (!vcpkg_valid_identifier(package)) {
-                throw std::runtime_error("Invalid vcpkg package name '" + package + "'");
+            if (!vcpkg_valid_identifier(package.name)) {
+                throw std::runtime_error("Invalid vcpkg package name '" + package.name + "'");
             }
-            ofs << "    \"" << package << '\"';
-            if (i + 1 < packages.size()) {
-                ofs << ',';
+            if (package.features.empty()) {
+                ofs << "    \"" << package.name << '\"';
+            } else {
+                ofs << "    {\n";
+                ofs << "        \"name\": \"" << package.name << "\",\n";
+                ofs << "        \"features\": [";
+                for (size_t j = 0; j < package.features.size(); j++) {
+                    const auto &feature = package.features[j];
+                    ofs << '\"' << feature << '\"';
+                    if (j + 1 < package.features.size()) {
+                        ofs << ',';
+                    }
+                }
+                ofs << "]\n";
+                ofs << "    }";
             }
+			if (i + 1 < packages.size()) {
+				ofs << ',';
+			}
             ofs << '\n';
         }
 

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -618,8 +618,8 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
                 ofs << "    \"" << package.name << '\"';
             } else {
                 ofs << "    {\n";
-                ofs << "        \"name\": \"" << package.name << "\",\n";
-                ofs << "        \"features\": [";
+                ofs << "      \"name\": \"" << package.name << "\",\n";
+                ofs << "      \"features\": [";
                 for (size_t j = 0; j < package.features.size(); j++) {
                     const auto &feature = package.features[j];
                     ofs << '\"' << feature << '\"';

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -616,9 +616,9 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
                 throw std::runtime_error("Invalid vcpkg package name '" + package.name + "'");
             }
             for (const auto &feature : features) {
-				if (!vcpkg_valid_identifier(feature)) {
-					throw std::runtime_error("Invalid vcpkg package feature '" + feature + "'");
-				}
+                if (!vcpkg_valid_identifier(feature)) {
+                    throw std::runtime_error("Invalid vcpkg package feature '" + feature + "'");
+                }
             }
             if (features.empty()) {
                 ofs << "    \"" << package.name << '\"';

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -511,7 +511,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) {
                     package.features.emplace_back(feature);
                 }
             } else {
-                throw std::runtime_error("Badly formed vcpkg package name");
+                throw std::runtime_error("Invalid vcpkg package '" + package_str + "'");
             }
             vcpkg.packages.emplace_back(std::move(package));
         }

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -504,7 +504,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) {
                 package.name = package_str;
             } else if (close_bracket != std::string::npos) {
                 package.name = package_str.substr(0, open_bracket);
-                auto features = package_str.substr(open_bracket + 1, close_bracket - open_bracket - 1);
+                const auto features = package_str.substr(open_bracket + 1, close_bracket - open_bracket - 1);
                 std::istringstream feature_stream{features};
                 std::string feature;
                 while (std::getline(feature_stream, feature, ',')) {


### PR DESCRIPTION
Adds support for vcpkg package features. For example:
```
[vcpkg]
version = "2021.12.01"
packages = [
    "imgui[docking-experimental,freetype,sdl2-binding,opengl3-binding]",
    "fmt",
    "pegtl",
    "nativefiledialog",
    "spdlog",
    "utfcpp",
    "nlohmann-json",
    "glad[gl-api-30]",
]
```
I've tested these changes on one of my projects.