### PR TITLE
Allow specifying install component name

### DIFF
--- a/include/project_parser.hpp
+++ b/include/project_parser.hpp
@@ -127,6 +127,7 @@ struct Install {
     std::vector<std::string> dirs;
     std::vector<std::string> configs;
     std::string destination;
+    std::string component;
 };
 
 struct Subdir {

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -1030,7 +1030,11 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
             auto files = std::make_pair("FILES", inst.files);
             auto configs = std::make_pair("CONFIGURATIONS", inst.configs);
             auto destination = std::make_pair("DESTINATION", inst.destination);
-            auto component = std::make_pair("COMPONENT", inst.targets.empty() ? "" : inst.targets.front());
+            auto component_name = inst.component;
+            if (component_name.empty() && !inst.targets.empty()) {
+                component_name = inst.targets.front();
+            }
+            auto component = std::make_pair("COMPONENT", component_name);
             ConditionScope cs(gen, inst.condition);
             cmd("install")(targets, dirs, files, configs, destination, component);
         }

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -551,6 +551,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) {
             i.optional("dirs", inst.dirs);
             i.optional("configs", inst.configs);
             i.required("destination", inst.destination);
+            i.optional("component", inst.component);
             installs.push_back(inst);
         }
     }


### PR DESCRIPTION
Sometimes you want a component to install a target, as well as some files. For example:

```toml
[[install]]
targets = ["MHRISE"]
destination = "MHRISE"

[[install]]
destination = "MHRISE"
files = ["dependencies/openvr/bin/win64/openvr_api.dll"]
```

This creates two install components, one which inherits the name of the target (`MHRISE`) and one that doesn't belong to any install component.

This PR lets you specify a component for the install so that you can do something like:

```toml
[[install]]
targets = ["MHRISE"]
destination = "MHRISE"
component = "MHRISE" # optional since its the same as the first target name

[[install]]
destination = "MHRISE"
files = ["dependencies/openvr/bin/win64/openvr_api.dll"]
component = "MHRISE"
```

Which lets you install the specific component along with the required files via command line:

```
cmake --install <build folder> --component MHRISE --prefix install
```

I found this necessary since while cmkr doesn't complain about the following:

```toml
[[install]]
targets = ["MHRISE"]
destination = "MHRISE"
files = ["dependencies/openvr/bin/win64/openvr_api.dll"]
```

CMake complains with: `[cmake]   install TARGETS given target "FILES" which does not exist.`


