### PR TITLE
error: fix warning, signedness of comparison

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,6 +1,7 @@
 #include "error.hpp"
 
 #include <cassert>
+#include <cstddef>
 
 namespace cmkr {
 namespace error {
@@ -20,6 +21,6 @@ static const char *err_string[] = {
 };
 
 const char *cmkr_error_status(int i) {
-    assert(i >= 0 && i < (sizeof(err_string) / sizeof(*(err_string))));
+    assert(i >= 0 && static_cast<size_t>(i) < (sizeof(err_string) / sizeof(*(err_string))));
     return err_string[i];
 }


### PR DESCRIPTION
cmkr/src/error.cpp:23:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   23 |     assert(i >= 0 && i < (sizeof(err_string) / sizeof(*(err_string))));