### PR TITLE
Rename `[settings]` to `[variables]`

### DIFF
--- a/docs/cmake-toml.md
+++ b/docs/cmake-toml.md
@@ -9,7 +9,8 @@ nav_order: 3
 
 This page is a reference for the options in the `cmake.toml` file. If you think anything is missing or unclear, please [edit this page](https://github.com/build-cpp/cmkr/edit/main/docs/cmake-toml.md) or open an [issue](https://github.com/build-cpp/cmkr/issues).
 
-See the [examples](/examples) section for concrete examples.
+This is a reference page. Check out the [examples](/examples) and the [cmkr topic](https://github.com/topics/cmkr) as well.
+{:.info}
 
 ## CMake configuration
 
@@ -92,6 +93,16 @@ message(STATUS "CMake injected after the add_subdirectory() call")
 include-before = ["cmake/before-subdir.cmake"]
 include-after = ["cmake/after-subdir.cmake"]
 ```
+
+## Variables
+
+```toml
+[variables]
+MYBOOL = true
+MYSTRING = "hello"
+```
+
+Variables emit a [`set`](https://cmake.org/cmake/help/latest/command/set.html) and can be used to configure subprojects and packages.
 
 ## Vcpkg
 

--- a/include/project_parser.hpp
+++ b/include/project_parser.hpp
@@ -14,7 +14,7 @@ using Condition = tsl::ordered_map<std::string, T>;
 
 using ConditionVector = Condition<std::vector<std::string>>;
 
-struct Setting {
+struct Variable {
     std::string name;
     std::string comment;
     mpark::variant<bool, std::string> val;
@@ -185,7 +185,7 @@ struct Project {
     Condition<std::string> cmake_after;
     ConditionVector include_before;
     ConditionVector include_after;
-    std::vector<Setting> settings;
+    std::vector<Variable> variables;
     std::vector<Option> options;
     std::vector<Package> packages;
     Vcpkg vcpkg;

--- a/src/cmake_generator.cpp
+++ b/src/cmake_generator.cpp
@@ -621,10 +621,9 @@ void generate_cmake(const char *path, const parser::Project *parent_project) {
         endl();
     }
 
-    // TODO: rename to 'variables'?
-    if (!project.settings.empty()) {
-        comment("Settings");
-        for (const auto &set : project.settings) {
+    if (!project.variables.empty()) {
+        comment("Variables");
+        for (const auto &set : project.variables) {
             std::string set_val;
             if (set.val.index() == 1) {
                 set_val = mpark::get<1>(set.val);

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -219,7 +219,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) : p
         cmake.required("version", cmake_version);
 
         if (cmake.contains("bin-dir")) {
-            throw std::runtime_error("bin-dir has been renamed to build-dir");
+            throw std::runtime_error(format_key_error("bin-dir has been renamed to build-dir", "bin-dir", cmake.find("bin-dir")));
         }
 
         cmake.optional("build-dir", build_dir);
@@ -473,7 +473,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) : p
     }
 
     if (checker.contains("bin")) {
-        throw std::runtime_error("[[bin]] has been renamed to [[target]]");
+        throw std::runtime_error(format_key_error("[[bin]] has been renamed to [target.<name>]", "", toml.at("bin")));
     }
 
     auto parse_target = [&](const std::string &name, TomlChecker &t, bool isTemplate) {
@@ -711,7 +711,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) : p
                     package.features.emplace_back(feature);
                 }
             } else {
-                throw std::runtime_error("Invalid vcpkg package '" + package_str + "'");
+                throw std::runtime_error(format_key_error("Invalid package name '" + package_str + "'", "packages", p));
             }
             vcpkg.packages.emplace_back(std::move(package));
         }

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -320,8 +320,12 @@ Project::Project(const Project *parent, const std::string &path, bool build) : p
     }
 
     if (checker.contains("settings")) {
+        throw std::runtime_error(format_key_error("[settings] has been renamed to [variables]", "", toml.at("settings")));
+    }
+
+    if (checker.contains("variables")) {
         using set_map = tsl::ordered_map<std::string, TomlBasicValue>;
-        const auto &sets = toml::find<set_map>(toml, "settings");
+        const auto &sets = toml::find<set_map>(toml, "variables");
         for (const auto &itr : sets) {
             Setting s;
             s.name = itr.first;


### PR DESCRIPTION
Previously:

```toml
[settings]
MY_VARIABLE = true
```

Now:

```toml
[variables]
MY_VARIABLE = true
```

Backwards compatibility is kept:

```toml
[variables]
VAR1 = true

[settings]
VAR2 = false
```

Is equivalent to:

```toml
[variables]
VAR1 = true
VAR2 = false
```

Shadowing variables results in an error.