### PR TITLE
Improve relative path functionality for `link-libraries`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: clang-format
         id: clang-format
-        uses: DoozyX/clang-format-lint-action@c3b2c943e924028b93a707a5b1b017976ab8d50c # v0.15
+        uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
         with:
           exclude: './third_party'
           extensions: 'c,h,cpp,hpp'


### PR DESCRIPTION
Now the following `cmake.toml` will also insert `${CMAKE_CURRENT_SOURCE_DIR}/` automatically:

```toml
[target.foo]
type = "executable"
link-libraries = ["test.lib"]
```

If `./test.lib` exists it will emit `${CMAKE_CURRENT_SOURCE_DIR}/test.lib` (instead of `test.lib` verbatim).