### PR TITLE
Fix warnings when options are not prefixed with the project name

### DIFF
--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -452,7 +452,7 @@ Project::Project(const Project *parent, const std::string &path, bool build) : p
             if (ncondition.find(nproject_prefix) == 0) {
                 ncondition = ncondition.substr(nproject_prefix.size());
             }
-            if (!ncondition.empty()) {
+            if (!ncondition.empty() && ncondition != o.name) {
                 if (conditions.contains(ncondition)) {
                     print_key_warning("Option '" + o.name + "' would create a condition '" + ncondition + "' that already exists", o.name, value);
                 }


### PR DESCRIPTION
```toml
[options]
foobar = false
```
will trigger following warning:

`[warning] Option 'foobar' would create a condition 'foobar' that already exists`

This is because options implicitly create conditions but with the project name prefix stripped, so for options without a prefix it will attempt to add the condition again just without the prefix which leads to this warning. 

The fix now checks if the normalized name is still the original name, if the name remains the same then the condition is always identical to the option and doesn't need a separate condition with the prefix removed. 