### PR TITLE
Suggest valid target keys for common typos

### DIFF
--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -1,11 +1,14 @@
 #include "project_parser.hpp"
 
 #include "fs.hpp"
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <deque>
+#include <limits>
 #include <stdexcept>
 #include <toml.hpp>
+#include <vector>
 
 namespace cmkr {
 namespace parser {
@@ -63,6 +66,26 @@ static void throw_key_error(const std::string &error, const toml::key &ky, const
     throw std::runtime_error(format_key_message("[error] " + error, ky, value));
 }
 
+static size_t levenshtein_distance(const std::string &left, const std::string &right) {
+    std::vector<size_t> previous(right.size() + 1);
+    std::vector<size_t> current(right.size() + 1);
+
+    for (size_t i = 0; i <= right.size(); i++) {
+        previous[i] = i;
+    }
+
+    for (size_t i = 1; i <= left.size(); i++) {
+        current[0] = i;
+        for (size_t j = 1; j <= right.size(); j++) {
+            const auto substitution = previous[j - 1] + (left[i - 1] == right[j - 1] ? 0 : 1);
+            current[j] = std::min({previous[j] + 1, current[j - 1] + 1, substitution});
+        }
+        previous.swap(current);
+    }
+
+    return previous.back();
+}
+
 static std::string suggest_key(const toml::key &key, const tsl::ordered_set<toml::key> &known_keys) {
     static const std::array<std::pair<const char *, const char *>, 3> suggestions = {{
         {"link-flags", "link-options"},
@@ -74,6 +97,30 @@ static std::string suggest_key(const toml::key &key, const tsl::ordered_set<toml
         if (key == suggestion.first && known_keys.contains(suggestion.second)) {
             return suggestion.second;
         }
+    }
+
+    std::string closest;
+    auto closest_distance = std::numeric_limits<size_t>::max();
+    const auto consider = [&](const std::string &candidate) {
+        const auto distance = levenshtein_distance(key, candidate);
+        if (distance < closest_distance) {
+            closest = candidate;
+            closest_distance = distance;
+        }
+    };
+
+    for (const auto &known_key : known_keys) {
+        consider(known_key);
+    }
+    for (const auto &suggestion : suggestions) {
+        if (known_keys.contains(suggestion.second)) {
+            consider(suggestion.first);
+        }
+    }
+
+    const auto longest = std::max(key.size(), closest.size());
+    if (closest_distance <= 3 && closest_distance * 3 <= longest) {
+        return closest;
     }
 
     return {};

--- a/src/project_parser.cpp
+++ b/src/project_parser.cpp
@@ -1,6 +1,7 @@
 #include "project_parser.hpp"
 
 #include "fs.hpp"
+#include <array>
 #include <cctype>
 #include <deque>
 #include <stdexcept>
@@ -60,6 +61,31 @@ static std::string format_key_message(const std::string &message, const toml::ke
 
 static void throw_key_error(const std::string &error, const toml::key &ky, const TomlBasicValue &value) {
     throw std::runtime_error(format_key_message("[error] " + error, ky, value));
+}
+
+static std::string suggest_key(const toml::key &key, const tsl::ordered_set<toml::key> &known_keys) {
+    static const std::array<std::pair<const char *, const char *>, 3> suggestions = {{
+        {"link-flags", "link-options"},
+        {"compile-flags", "compile-options"},
+        {"flags", "compile-options"},
+    }};
+
+    for (const auto &suggestion : suggestions) {
+        if (key == suggestion.first && known_keys.contains(suggestion.second)) {
+            return suggestion.second;
+        }
+    }
+
+    return {};
+}
+
+static void throw_unknown_key(const toml::key &key, const TomlBasicValue &value, const tsl::ordered_set<toml::key> &known_keys) {
+    std::string error = "Unknown key '" + key + "'";
+    const auto suggestion = suggest_key(key, known_keys);
+    if (!suggestion.empty()) {
+        error += " (did you mean '" + suggestion + "'?)";
+    }
+    throw_key_error(error, key, value);
 }
 
 static void print_key_warning(const std::string &message, const toml::key &ky, const TomlBasicValue &value) {
@@ -147,18 +173,18 @@ class TomlChecker {
 
                 for (const auto &jtr : itr.second.as_table()) {
                     if (!m_visited.contains(jtr.first)) {
-                        throw_key_error("Unknown key '" + jtr.first + "'", jtr.first, jtr.second);
+                        throw_unknown_key(jtr.first, jtr.second, m_visited);
                     }
                 }
             } else if (!m_visited.contains(ky)) {
                 if (itr.second.is_table()) {
                     for (const auto &jtr : itr.second.as_table()) {
                         if (!m_visited.contains(jtr.first)) {
-                            throw_key_error("Unknown key '" + jtr.first + "'", jtr.first, jtr.second);
+                            throw_unknown_key(jtr.first, jtr.second, m_visited);
                         }
                     }
                 }
-                throw_key_error("Unknown key '" + ky + "'", ky, itr.second);
+                throw_unknown_key(ky, itr.second, m_visited);
             } else if (ky == "condition") {
                 std::string condition = itr.second.as_string();
                 if (!conditions.contains(condition) && Project::is_condition_name(condition)) {
@@ -200,7 +226,7 @@ class TomlCheckerRoot {
         if (check_root) {
             for (const auto &itr : m_root.as_table()) {
                 if (!m_visisted.contains(itr.first)) {
-                    throw_key_error("Unknown key '" + itr.first + "'", itr.first, itr.second);
+                    throw_unknown_key(itr.first, itr.second, m_visisted);
                 }
             }
         }


### PR DESCRIPTION
## what changed

when someone writes link-flags, compile-flags, or flags, cmkr now suggests the config key that actually exists.

the suggestion is only shown when that key is valid for the current target type.

## why

these are pretty natural names to try, and the old error did not give much to go on.

## checks

- git diff --check passes.
- github ci passed on the previous revision; the amended commit will rerun it.
- the local machine does not have cmake, ninja, or a c++ compiler installed.

fixes #134